### PR TITLE
Add installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,8 @@ Issues, Bugs, Limitations
 
 * This service **does not handle any kind of quota**.
 * The format in which the files are stored is **not** compatible with ``mod_http_upload`` -- so you'll lose all uploaded files when switching.
+* This blindly trusts the clients Content-Type. I don't think this is a major issue, because we also tell the browser to blindly trust the clients MIME type. This, in addition with forcing all but a white list of MIME types to be downloaded instead of shown inline, should provide safety against any type of XSS attacks.
+* I have no idea about web security. The headers I set may be subtly wrong and circumvent all security measures I intend this to have. Please double-check for yourself and report if you find anything amiss.
 
 Example Installation instructions
 =================================
@@ -82,6 +84,3 @@ Configure your webserver:
 
 As final step you need to point your external webserver to your xmpp-http-upload flask app.
 Check the ``contrib`` directory, there is an example for nginx there.
-=======
-* This blindly trusts the clients Content-Type. I don't think this is a major issue, because we also tell the browser to blindly trust the clients MIME type. This, in addition with forcing all but a white list of MIME types to be downloaded instead of shown inline, should provide safety against any type of XSS attacks.
-* I have no idea about web security. The headers I set may be subtly wrong and circumvent all security measures I intend this to have. Please double-check for yourself and report if you find anything amiss.

--- a/README.rst
+++ b/README.rst
@@ -45,3 +45,36 @@ Issues, Bugs, Limitations
 
 * This service **does not handle any kind of quota**.
 * The format in which the files are stored is **not** compatible with ``mod_http_upload`` -- so you'll lose all uploaded files when switching.
+
+Example Installation instructions
+=================================
+
+Example instructions, adjust accordingly.
+
+I assume your webserver uses ``www-data`` as service account. If you have a different user update the systemd service and the permissions for the data directory.
+
+Clone and install::
+
+    git clone https://github.com/horazont/xmpp-http-upload
+    sudo mv xmpp-http-upload /opt/xmpp-http-upload
+    cd /opt/xmpp-http-upload
+    copy config.example.py config.py
+    sudo python3 setup.py install
+
+Edit ``config.py`` and change ``SECRET_KEY``. Be sure to only change between ``''``.
+
+Create the upload directory::
+
+    sudo mkdir /var/lib/xmpp-http-upload
+    sudo chown www-data.www-data /var/lib/xmpp-http-upload
+
+Enable systemd service::
+
+    sudo copy contrib/xmpp-http-upload.service /etc/systemd/system
+    sudo systemctl enable xmpp-http-upload.service
+    sudo systemctl start xmpp-http-upload.service
+
+Configure your webserver:
+
+As final step you need to point your external webserver to your xmpp-http-upload flask app.
+Check the ``contrib`` directory, there is an example for nginx there.

--- a/config.example.py
+++ b/config.example.py
@@ -1,0 +1,2 @@
+SECRET_KEY = b'your-secret-key'
+DATA_ROOT = "/var/lib/xmpp-http-upload"

--- a/contrib/nginx-example.conf
+++ b/contrib/nginx-example.conf
@@ -1,0 +1,7 @@
+# Include this snippet in your nginx config.
+# Make sure to preserve the trailing slashes if you change the location.
+
+location /upload/ {
+	proxy_pass http://127.0.0.1:5000/;
+	client_max_body_size 100M;
+}

--- a/contrib/nginx-example.conf
+++ b/contrib/nginx-example.conf
@@ -2,6 +2,6 @@
 # Make sure to preserve the trailing slashes if you change the location.
 
 location /upload/ {
-	proxy_pass http://127.0.0.1:5000/;
+	proxy_pass http://localhost:5000/;
 	client_max_body_size 100M;
 }

--- a/contrib/xmpp-http-upload.service
+++ b/contrib/xmpp-http-upload.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=XMPP HTTP Upload Service
+
+[Service]
+Type=simple
+
+User=www-data
+Group=www-data
+
+Environment=FLASK_APP=/opt/xmpp-http-upload/xhu.py
+Environment=XMPP_HTTP_UPLOAD_CONFIG=/opt/xmpp-http-upload/config.py
+ExecStart=/usr/local/bin/flask run
+
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/xmpp-http-upload.service
+++ b/contrib/xmpp-http-upload.service
@@ -9,7 +9,7 @@ Group=www-data
 
 Environment=FLASK_APP=/opt/xmpp-http-upload/xhu.py
 Environment=XMPP_HTTP_UPLOAD_CONFIG=/opt/xmpp-http-upload/config.py
-ExecStart=/usr/local/bin/flask run
+ExecStart=/usr/bin/flask run
 
 Restart=on-failure
 RestartSec=10


### PR DESCRIPTION
I added some installation instructions and example files for less experienced users.

Maybe check config.example.py, I'm not sure if the SECRET_KEY variable needs to be specified with a b in front. However everything else threw tracebacks that a bytes object is expected.