### PR TITLE
Use utf-8 instead of ascii to encode the HMAC input string

### DIFF
--- a/xhu.py
+++ b/xhu.py
@@ -113,7 +113,7 @@ def put_file(path):
 
     verification_key = flask.request.args.get("v", "")
     length = int(flask.request.headers.get("Content-Length", 0))
-    hmac_input = (path + " " + str(length)).encode("ascii")
+    hmac_input = "{} {}".format(path, length).encode("utf-8")
     key = app.config["SECRET_KEY"]
     mac = hmac.new(key, hmac_input, hashlib.sha256)
     digest = mac.hexdigest()


### PR DESCRIPTION
It seems that ascii is not suitable for this task, especially when we have unicode characters in input.
I replaced ascii with utf-8 and now it's working fine.