### PR TITLE
Add CORS support

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -1,2 +1,3 @@
 SECRET_KEY = b'your-secret-key'
 DATA_ROOT = "/var/lib/xmpp-http-upload"
+ENABLE_CORS = False

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as f:
 
 install_requires = [
     'flask~=0.12',
+    'flask-cors~=3.0.3',
 ]
 
 setup(

--- a/xhu.py
+++ b/xhu.py
@@ -34,6 +34,10 @@ app = flask.Flask("xmpp-http-upload")
 app.config.from_envvar("XMPP_HTTP_UPLOAD_CONFIG")
 application = app
 
+if app.config['ENABLE_CORS']:
+    from flask_cors import CORS
+    CORS(app)
+
 
 def sanitized_join(path: str, root: pathlib.Path) -> pathlib.Path:
     result = (root / path).absolute()


### PR DESCRIPTION
I needed CORS support while testing (didn't want to set up an external webserver) so I quickly added support for it.

Adds new config variable `ENABLE_CORS` and if it's set to `True`, then [flask-cors](https://flask-cors.readthedocs.io/en/latest/) needs to be installed as well.

I see you have no `requirements.txt` file, generally one would put dependencies in there.