### PR TITLE
Add ability to maintain quotas and file logging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,10 +44,22 @@ The configuration file must contain the following keys:
   Allow cross-origin access to all endpoints unconditionally. This is needed
   to allow web clients to use the upload feature.
 
+Setting an upload quota
+-----------------------
+
+A quota will be enforced if it's received from the XMPP server in the PUT
+request as a `q` URL parameter.
+
+The quota is enforced on the parent directory of the UUID directory containing
+the file and metadata.
+
+If this parent directory is global to all users, then the quota is also global,
+otherwise if this parent directory is specific to each user, then the quota is
+also per user.
+
 Issues, Bugs, Limitations
 =========================
 
-* This service **does not handle any kind of quota**.
 * The format in which the files are stored is **not** compatible with ``mod_http_upload`` -- so you'll lose all uploaded files when switching.
 * This blindly trusts the clients Content-Type. I don't think this is a major issue, because we also tell the browser to blindly trust the clients MIME type. This, in addition with forcing all but a white list of MIME types to be downloaded instead of shown inline, should provide safety against any type of XSS attacks.
 * I have no idea about web security. The headers I set may be subtly wrong and circumvent all security measures I intend this to have. Please double-check for yourself and report if you find anything amiss.

--- a/xhu.py
+++ b/xhu.py
@@ -25,6 +25,7 @@ import fnmatch
 import hashlib
 import hmac
 import json
+import logging
 import os
 import pathlib
 import shutil
@@ -37,6 +38,13 @@ app = flask.Flask("xmpp-http-upload")
 app.config.from_envvar("XMPP_HTTP_UPLOAD_CONFIG")
 application = app
 
+if app.config['LOGDIR']:
+    logging.basicConfig(
+        filename='{}/xhu.log'.format(app.config['LOGDIR']),
+        filemode='a',
+        level=logging.INFO
+    )
+logger = logging.getLogger(__name__)
 
 if app.config['ENABLE_CORS']:
     from flask_cors import CORS
@@ -99,6 +107,10 @@ def apply_quota(root: pathlib.Path, quota: int):
         file_list.sort(key=lambda a: a[0])
         while (bytes >= 0):
             modified, path, name, size = file_list.pop()
+            logger.info(
+                "Removing file {}/{} to maintain quota of {}"
+                .format(path, name, quota)
+            )
             shutil.rmtree(path)
             bytes -= size
 


### PR DESCRIPTION
The README diff contains more info on the changes made.

I'm planning to update Prosody's mod_http_upload_external to prepend the hashed/salted JID in the PUT URLs, so that admins can identify the files uploaded for a particular JID.

This can help with GDPR compliance (e.g. removal of particular user's data upon request) and also makes per-user quotas possible.

If the hashed/salted JID is not in the URL, then the quota is enforced globally across all users.